### PR TITLE
force python3 for pytest

### DIFF
--- a/nbresult/__init__.py
+++ b/nbresult/__init__.py
@@ -28,7 +28,7 @@ class ChallengeResult:
     def check(self):
         """returns test output on the ChallengeResult"""
         path = f"tests/test_{self.name}.py"
-        command = f"PYTHONDONTWRITEBYTECODE=1 pytest -v --color=yes {path}"
+        command = f"PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -v --color=yes {path}"
         res = os.popen(command)
         result = res.read()
         if res.close() is None:


### PR DESCRIPTION
Following discussion on slack https://lewagon-alumni.slack.com/archives/C015E0C601F/p1621232063486000
This helps Colab understand how to use our nbresult package properly.
Before
![image](https://user-images.githubusercontent.com/22095643/118613161-c7e0cd80-b7be-11eb-9bbd-b03b39d4f290.png)
After 
![Screenshot 2021-05-18 at 09 50 01](https://user-images.githubusercontent.com/22095643/118613198-cf07db80-b7be-11eb-9098-26601e0d39c7.png)

Also tested locally
![image](https://user-images.githubusercontent.com/22095643/118613682-463d6f80-b7bf-11eb-8d81-2e47647c6819.png)
