### PR TITLE
replace method for opening pickle files

### DIFF
--- a/nbresult/__init__.py
+++ b/nbresult/__init__.py
@@ -3,6 +3,7 @@ import os
 import unittest
 import re
 import sys
+import pandas as pd
 
 
 class ChallengeResult:
@@ -49,4 +50,4 @@ class ChallengeResultTestCase(unittest.TestCase):
         klass = self.__class__.__name__
         name = re.sub(r'(?<!^)(?=[A-Z])', '_', klass).lower()[len('test_'):]
         result_file = os.path.join(os.getcwd(), "tests", f"{name}.pickle")
-        self.result = pickle.load(open(result_file, 'rb'))
+        self.result = pd.read_pickle(result_file)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name='nbresult',
-    version='0.0.4',
+    version='0.0.5',
     description='Extract results from Jupyter notebooks',
     license="MIT",
     long_description=long_description,


### PR DESCRIPTION
Following multiple issues coming from different cities where local tests are passing and the ones on Kitt are failing for some of the students.

According to this [thread](https://github.com/pandas-dev/pandas/issues/16474) you can't read a pickle file created with a different pandas version using `pickle.load`. I replaced the method to `pd.read_pickle` which is meant to solve the issue.

Tested locally with my own notebooks, everything runs well but it would be great if you cross checked it before we update entire package for the Data program.

What would be the procedure after? Post on `data-teachers` to ask students to update the `nbresult`? Send an automated message to all running batches?