### PR TITLE
Replace hardcoded `python3` with `sys.executable`

### DIFF
--- a/.python-version
+++ b/.python-version
@@ -1,1 +1,0 @@
-nbresult

--- a/nbresult/__init__.py
+++ b/nbresult/__init__.py
@@ -55,7 +55,7 @@ class ChallengeResult:
         """returns test output on the ChallengeResult"""
         tests_path = self._locate_tests()
         file_path = f"test_{self.name}.py"
-        command = ["python3", "-m", "pytest", "-v", "--color=yes", file_path]
+        command = [sys.executable, "-m", "pytest", "-v", "--color=yes", file_path]
         sub_process = subprocess.Popen(command,
                              cwd=tests_path, # set current working directory
                              stdin=subprocess.PIPE,

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 setup(name='nbresult',
-      version='0.0.9',
+      version='0.1.0',
       description='Extract results from Jupyter notebooks',
       license="MIT",
       long_description=long_description,


### PR DESCRIPTION
Fixes https://github.com/lewagon/help/issues/5229

Re-reading the long conversation happenning, I came to the conclusion that it does not harm to have the full path of the current running Python instead of hardcoded (kudos @gmanchon for finding this one).

I suggest we merge this one and re-release the `nbresult` package to `0.1.0`, then we do a new release of https://github.com/lewagon/data-runner 

WDYT?