### PR TITLE
Adapt post-check message to context

### DIFF
--- a/nbresult/__init__.py
+++ b/nbresult/__init__.py
@@ -69,7 +69,7 @@ class ChallengeResult:
                 tests_directory = f'{tests_directory}/{self.subdir}'
 
             nbresult_post_check_message = os.getenv('NBRESULT_POST_CHECK_MESSAGE')
-            if nbresult_post_check_message == 'JUPTERLAB':
+            if nbresult_post_check_message == 'JUPYTERLAB':
                 result = f"""
 {result}\n
 :100: You can now submit your code through the JupyterLab git GUI. Submit by adding, committing and pushing the folder {tests_directory} (including all of its contents)!

--- a/nbresult/__init__.py
+++ b/nbresult/__init__.py
@@ -67,10 +67,21 @@ class ChallengeResult:
             tests_directory = 'tests'
             if self.subdir:
                 tests_directory = f'{tests_directory}/{self.subdir}'
-            result = f"""
-            {result}\n
-            :100: You can now submit your code through the JupyterLab git GUI. Submit by adding, committing and pushing the folder {tests_directory} (including all of its contents)!
-            """
+
+            nbresult_post_check_message = os.getenv('NBRESULT_POST_CHECK_MESSAGE')
+            if nbresult_post_check_message == 'JUPTERLAB':
+                result = f"""
+{result}\n
+:100: You can now submit your code through the JupyterLab git GUI. Submit by adding, committing and pushing the folder {tests_directory} (including all of its contents)!
+"""
+            else:
+                result = f"""
+{result}\n
+💯 You can commit your code:\n
+\033[1;32mgit\033[39m add {tests_directory}/{self.name}.pickle\n
+\033[32mgit\033[39m commit -m \033[33m'Completed {self.name} step'\033[39m\n
+\033[32mgit\033[39m push origin master
+"""
 
         return result
 

--- a/nbresult/__init__.py
+++ b/nbresult/__init__.py
@@ -72,7 +72,7 @@ class ChallengeResult:
             if nbresult_post_check_message == 'JUPYTERLAB':
                 result = f"""
 {result}\n
-:100: You can now submit your code through the JupyterLab git GUI. Submit by adding, committing and pushing the folder {tests_directory} (including all of its contents)!
+:100: You can now save your changes and move on to the next challenge.
 """
             else:
                 result = f"""

--- a/nbresult/__init__.py
+++ b/nbresult/__init__.py
@@ -69,10 +69,7 @@ class ChallengeResult:
                 tests_directory = f'{tests_directory}/{self.subdir}'
             result = f"""
 {result}\n
-💯 You can commit your code:\n
-\033[1;32mgit\033[39m add {tests_directory}/{self.name}.pickle\n
-\033[32mgit\033[39m commit -m \033[33m'Completed {self.name} step'\033[39m\n
-\033[32mgit\033[39m push origin master
+💯 You can submit your code through the JupyterLab git GUI!
 """
 
         return result

--- a/nbresult/__init__.py
+++ b/nbresult/__init__.py
@@ -68,9 +68,9 @@ class ChallengeResult:
             if self.subdir:
                 tests_directory = f'{tests_directory}/{self.subdir}'
             result = f"""
-{result}\n
-💯 You can submit your code through the JupyterLab git GUI!
-"""
+            {result}\n
+            :100: You can now submit your code through the JupyterLab git GUI. Submit by adding, committing and pushing the folder {tests_directory} (including all of its contents)!
+            """
 
         return result
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(name='nbresult',
       version='0.1.1',
-      description='Adapt post check message to context.',
+      description='Extract results from Jupyter notebooks',
       license="MIT",
       long_description=long_description,
       long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,8 @@ with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 setup(name='nbresult',
-      version='0.0.9',
-      description='Extract results from Jupyter notebooks',
+      version='0.1.1',
+      description='Adapt post check message to context.',
       license="MIT",
       long_description=long_description,
       long_description_content_type="text/markdown",

--- a/tests/test_challenge_result.py
+++ b/tests/test_challenge_result.py
@@ -139,4 +139,4 @@ class TestChallengeResult(unittest.TestCase):
         os.chdir(cwd)
         os.remove(os.path.join(tests_dir, 'unicity.pickle'))
         os.environ['NBRESULT_POST_CHECK_MESSAGE'] = ''
-        self.assertIn(f'You can now submit your code through the JupyterLab', output)
+        self.assertIn(f'You can now save your changes and move on to the next challenge', output)

--- a/tests/test_challenge_result.py
+++ b/tests/test_challenge_result.py
@@ -109,3 +109,34 @@ class TestChallengeResult(unittest.TestCase):
         result.write()
         output = result.check()
         self.assertIn(f'add tests/{subdir}/unicity.pickle', output)
+
+    def test_post_check_message_when_env_not_set(self):
+        cwd = os.getcwd()
+        challenge_dir = os.path.join(os.path.dirname(__file__), 'fixtures', 'package_challenge', 'toto')
+        subdir = 'first_tests'
+        tests_dir = os.path.join(challenge_dir, 'tests', subdir)
+        os.chdir(challenge_dir)
+        result = ChallengeResult('unicity', subdir=subdir, dummy=42)
+        result.write()
+        output = result.check()
+        # Manual tear down
+        os.chdir(cwd)
+        os.remove(os.path.join(tests_dir, 'unicity.pickle'))
+
+        self.assertIn(f'You can commit your code', output)
+
+    def test_post_check_message_when_env_set_to_jupyterlab(self):
+        cwd = os.getcwd()
+        challenge_dir = os.path.join(os.path.dirname(__file__), 'fixtures', 'package_challenge', 'toto')
+        subdir = 'first_tests'
+        tests_dir = os.path.join(challenge_dir, 'tests', subdir)
+        os.chdir(challenge_dir)
+        result = ChallengeResult('unicity', subdir=subdir, dummy=42)
+        result.write()
+        os.environ['NBRESULT_POST_CHECK_MESSAGE'] = 'JUPYTERLAB'
+        output = result.check()
+        # Manual tear down
+        os.chdir(cwd)
+        os.remove(os.path.join(tests_dir, 'unicity.pickle'))
+        os.environ['NBRESULT_POST_CHECK_MESSAGE'] = ''
+        self.assertIn(f'You can now submit your code through the JupyterLab', output)


### PR DESCRIPTION
This PR aims at publishing a new `0.1.1` version of the package where we can set the post check output message w/ an `NBRESULT_POST_CHECK_MESSAGE` environment variable, to avoid having to pip install using the Github repo on a specific branch cf https://github.com/lewagon/data-analytics-with-python/commit/05323dc893e4c8eca7834bb5e50252111b41171c 👌 