### PR TITLE
Add GHA to publish package to Pypi on Release

### DIFF
--- a/.github/workflows/publish-on-release.yml
+++ b/.github/workflows/publish-on-release.yml
@@ -25,5 +25,5 @@ jobs:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
         run: |
-          python setup.py sdist bdist_wheel
-          twine upload dist/*
+          make build
+          make publish

--- a/.github/workflows/publish-on-release.yml
+++ b/.github/workflows/publish-on-release.yml
@@ -1,0 +1,29 @@
+name: "Build and Publish Package on Pypi"
+
+on:
+  release:
+    types: [published, edited]
+
+jobs:
+  publish-on-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.8
+
+      - name: Install dependencies
+        run: |
+          pip install setuptools wheel twine
+
+      - name: Build and publish on Pypi
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: |
+          python setup.py sdist bdist_wheel
+          twine upload dist/*


### PR DESCRIPTION
## Context
Follow-up to https://github.com/lewagon/nbresult/pull/13#issuecomment-2591957165

ℹ️ New org secret defined at https://github.com/organizations/lewagon/settings/secrets/actions/PYPI_API_TOKEN

